### PR TITLE
Fix link when PIE is enabled by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,19 @@ OBJ_FILES=$(ASM_FILES:.asm=.o)
 TEST_ASM_FILES=$(wildcard test/*.asm)
 TEST_OBJ_FILES=$(TEST_ASM_FILES:.asm=.o)
 
+CC = gcc
+
+# $(call check_cc_option,<option>)
+define check_cc_option
+$(shell printf "int main(void){ return 0; }\n" \
+        | $(CC) -Wall -Werror -x c $(1) -c - -o /dev/null 2> /dev/null \
+        && printf -- "%s" $(1))
+endef
+
+LDFLAGS += $(call check_cc_option,-no-pie)
+
 src/webapp: $(OBJ_FILES)
-	gcc $(OBJ_FILES) -o src/webapp
+	gcc $(LDFLAGS) $(OBJ_FILES) -o src/webapp
 
 test/test: $(TEST_OBJ_FILES)
 	gcc $(TEST_OBJ_FILES) -o test/test


### PR DESCRIPTION
The code produced by the assembler isn't position-independent, which the
linker needs to be aware of. This is done with the -no-pie gcc option,
but this option is recent and isn't supported by older compilers where
PIE isn't enabled by default (and thus not needed).

As a result, add a Makefile macro to test for the support of compiler
options, and if -no-pie is supported, add it to the linker flags.